### PR TITLE
Normalise paths to generic format

### DIFF
--- a/include/vfspp/FileInfo.hpp
+++ b/include/vfspp/FileInfo.hpp
@@ -91,7 +91,7 @@ public:
 private:
     void Configure(const std::string& basePath, const std::string& fileName, bool isDir)
     {
-        m_Path = fs::path(basePath) / fs::path(fileName);
+        m_Path = (fs::path(basePath) / fs::path(fileName)).generic_string();
         m_IsDir = isDir;
     }
     


### PR DESCRIPTION
Resolve #13 by converting the std::filesystem::path in FileInfo to generic (POSIX) format, which is what vfspp seems to expect.

Otherwise on Windows you have to use forward slashes in the parts of paths which are virtual, and backslashes in the parts that are real, eg: '/assets/shaders\\frag.glsl', or it won't find the file.