### PR TITLE
Fixing missing CloseFile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@
 /build
 /examples/build
 .vscode/settings.json
+
+/out/**

--- a/include/vfspp/ZipFileSystem.hpp
+++ b/include/vfspp/ZipFileSystem.hpp
@@ -144,7 +144,13 @@ public:
     {
         return false;
     }
-
+    /*
+    * Close file 
+    */
+    virtual void CloseFile(IFilePtr file) override
+    {
+        //NO-OP
+    }
     /*
      * Check if file exists on filesystem
      */


### PR DESCRIPTION
Added CloseFile override for ZipFileSystem
added default ignore for cmake in-source builds (as they are common using Visual Studio and CPM/FetchContent)