### PR TITLE
Build fixes 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@
 /build
 /examples/build
 .vscode/settings.json
+
+/out/**

--- a/include/vfspp/NativeFile.hpp
+++ b/include/vfspp/NativeFile.hpp
@@ -246,7 +246,7 @@ private:
         m_Mode = mode;
         m_IsReadOnly = true;
         
-        std::ios_base::openmode open_mode = (std::ios_base::openmode)0x00;
+        std::ios_base::openmode open_mode = std::ios_base::binary;
         if ((mode & FileMode::Read) == FileMode::Read) {
             open_mode |= std::fstream::in;
         }

--- a/include/vfspp/ZipFileSystem.hpp
+++ b/include/vfspp/ZipFileSystem.hpp
@@ -144,7 +144,13 @@ public:
     {
         return false;
     }
-
+    /*
+    * Close file 
+    */
+    virtual void CloseFile(IFilePtr file) override
+    {
+        //NO-OP
+    }
     /*
      * Check if file exists on filesystem
      */


### PR DESCRIPTION
Add CloseFile override for ZipFileSystem
Files should be opened in binary mode, else reading from them yield unexpected results (e.g. reading an mp3-file)
add gitignore for out (default for CPM/FetchContent/Visual Studio in-source builds)