### PR TITLE
Add an opportunity to retrieve the absolute path for a relative path.

### DIFF
--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -1,6 +1,7 @@
 #include "vfspp/VFS.h"
 
 using namespace vfspp;
+using namespace std::string_view_literals;
 
 void PrintFile(const std::string& msg, IFilePtr file)
 {
@@ -30,6 +31,7 @@ int main()
 
     printf("Native filesystem test:\n");
 
+	auto test = vfs->AbsolutePath("/test.txt"sv);
     IFilePtr file = vfs->OpenFile(FileInfo("/test.txt"), IFile::FileMode::ReadWrite);
     if (file && file->IsOpened()) {
         char data[] = "The quick brown fox jumps over the lazy dog\n";


### PR DESCRIPTION
Hello there!

I added an opportunity to get an absolute path from your VFS, sometimes it might be useful, e.g.:
```cpp
auto shaderPath = m_vfs->AbsolutePath("/shaders/test_shader.hlsl"sv);
//-- here is convert from string to wstring(shaderPathW).
ok = D3DCompileFromFile(shaderPathW, nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr);
```

Perhaps you'll decide that it is a good point to have it in your library.