### PR TITLE
cmake: Increase of the minimum required cmake version to 3.5 for comp…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.50)
 
 # Project name and version
 project(vfspp VERSION 1.0 LANGUAGES CXX)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.50)
 
 project(vfsppexample)
 


### PR DESCRIPTION
Backward compatibility of cmake 4.0 is only possible up to version 3.5.

cmake 4.0:  "Compatibility with CMake < 3.5 has been removed from CMake."